### PR TITLE
Fix argparse type for dataset_txt_or_dir_paths

### DIFF
--- a/mid_timestep/mid_timestep_flux.py
+++ b/mid_timestep/mid_timestep_flux.py
@@ -168,7 +168,7 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser(description="Find optimal timestep for diffusion model")
     
-    parser.add_argument("--dataset_txt_or_dir_paths", type=str, nargs='+', help="List of dataset paths or txt files containing paths")
+    parser.add_argument("--dataset_txt_or_dir_paths", type=str, nargs='+', help="List of dataset paths or txt files containing paths (multiple allowed)")
     parser.add_argument("--flux_path", default="black-forest-labs/FLUX.1-dev",
                        help="Path to FLUX model")
     parser.add_argument("--resolution", type=int, default=1024,

--- a/mid_timestep/mid_timestep_flux.py
+++ b/mid_timestep/mid_timestep_flux.py
@@ -168,7 +168,7 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser(description="Find optimal timestep for diffusion model")
     
-    parser.add_argument("--dataset_txt_or_dir_paths", type=list, nargs='+', help="List of dataset paths or txt files containing paths")
+    parser.add_argument("--dataset_txt_or_dir_paths", type=str, nargs='+', help="List of dataset paths or txt files containing paths")
     parser.add_argument("--flux_path", default="black-forest-labs/FLUX.1-dev",
                        help="Path to FLUX model")
     parser.add_argument("--resolution", type=int, default=1024,

--- a/mid_timestep/mid_timestep_sd.py
+++ b/mid_timestep/mid_timestep_sd.py
@@ -142,7 +142,7 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser(description="Find optimal timestep for diffusion model")
     
-    parser.add_argument("--dataset_txt_or_dir_paths", type=str, nargs='+', help="List of dataset paths or txt files containing paths")
+    parser.add_argument("--dataset_txt_or_dir_paths", type=str, nargs='+', help="List of dataset paths or txt files containing paths (multiple allowed)")
     parser.add_argument("--sd_path", default="stabilityai/stable-diffusion-2-1",
                        help="Path to sd model")
     parser.add_argument("--resolution", type=int, default=512, 

--- a/mid_timestep/mid_timestep_sd.py
+++ b/mid_timestep/mid_timestep_sd.py
@@ -142,7 +142,7 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser(description="Find optimal timestep for diffusion model")
     
-    parser.add_argument("--dataset_txt_or_dir_paths", type=list, nargs='+', help="List of dataset paths or txt files containing paths")
+    parser.add_argument("--dataset_txt_or_dir_paths", type=str, nargs='+', help="List of dataset paths or txt files containing paths")
     parser.add_argument("--sd_path", default="stabilityai/stable-diffusion-2-1",
                        help="Path to sd model")
     parser.add_argument("--resolution", type=int, default=512, 


### PR DESCRIPTION
Using `type=list` with `nargs='+'` leads to unintended behavior:
each input string is converted into a list of characters.

For example:
--dataset_txt_or_dir_paths a b

becomes:
[['a'], ['b']]

instead of:
['a', 'b']

This PR fixes it by using `type=str`, which is the correct usage for argparse with nargs.